### PR TITLE
Add scale to bubble plots

### DIFF
--- a/R/plot_bubbles.R
+++ b/R/plot_bubbles.R
@@ -27,11 +27,6 @@ plot_bubbles <- function(mutation_data,
                                   circle_spacing = 1,
                                   circle_outline = "none",
                                   circle_resolution = 50) {
-  
-  library(ggplot2)
-  library(dplyr)
-  library(rlang)
-  library(packcircles)
 
   if (!requireNamespace("RColorBrewer")) {
     stop("You need the package RColorBrewer to run this function.")


### PR DESCRIPTION
As the title says, adds a scale.

It is included at the bottom of the plot, or, if faceted - in the last facet.

![image](https://github.com/user-attachments/assets/377a9619-f80e-4cc0-94c4-eae7b9b5bcd0)
